### PR TITLE
fix: accept and store raw field in log endpoint

### DIFF
--- a/server/api/log/[channelid].post.ts
+++ b/server/api/log/[channelid].post.ts
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
         z.literal("time"),
       ]),
       message: z.string().optional(),
+      raw: z.string().optional(),
       type: z.union([z.literal("json"), z.literal("text")]).optional(),
       thread: z.number().optional(),
     })
@@ -49,6 +50,7 @@ export default defineEventHandler(async (event) => {
     data: {
       level: parsedBody.data.level || "info",
       message: parsedBody.data.message || "",
+      raw: parsedBody.data.raw || null,
       type: parsedBody.data.type || "text",
       thread: parsedBody.data.thread || -1,
       channel_id: channelid,


### PR DESCRIPTION
The log endpoint was not accepting a raw field, causing structured JSON log data to never be stored

## Summary by Sourcery

Bug Fixes:
- Ensure the log endpoint accepts a raw field so structured JSON log data is correctly stored.